### PR TITLE
Speedup get_output_inv

### DIFF
--- a/circular_saw.lua
+++ b/circular_saw.lua
@@ -84,6 +84,8 @@ function circular_saw:get_output_inv(modname, material, amount, max)
 	if (not max or max < 1 or max > 99) then max = 99 end
 
 	local list = {}
+	local pos = #list
+
 	-- If there is nothing inside, display empty inventory:
 	if amount < 1 then
 		return list
@@ -91,8 +93,9 @@ function circular_saw:get_output_inv(modname, material, amount, max)
 
 	for i, t in ipairs(circular_saw.names) do
 		local cost = circular_saw.cost_in_microblocks[i]
-		table.insert(list, modname .. ":" .. t[1] .. "_" .. material .. t[2]
-				.. " " .. math.min(math.floor(amount/cost), max))
+		pos = pos + 1
+		list[pos] = modname .. ":" .. t[1] .. "_" .. material .. t[2]
+				.. " " .. math.min(math.floor(amount/cost), max)
 	end
 	return list
 end


### PR DESCRIPTION
`table.insert()` is a mediocre performer. 

The benchmark is here : http://forums.civfanatics.com/showthread.php?t=463488

And confirmed on many websites such as : 
- http://lua-users.org/wiki/OptimisationCodingTips
- http://stackoverflow.com/questions/154672/what-can-i-do-to-increase-the-performance-of-a-lua-program