### PR TITLE
Add circular crafting rule to 3-microblock stairs

### DIFF
--- a/stairsplus/microblocks.lua
+++ b/stairsplus/microblocks.lua
@@ -112,6 +112,12 @@ function stairsplus:register_micro(modname, subname, recipeitem, fields)
 	
 	minetest.register_craft({
 		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 3",
+		recipe = {modname .. ":stair_" .. subname .. "_right_half"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
 		output = modname .. ":micro_" .. subname .. " 2",
 		recipe = {modname .. ":panel_" .. subname},
 	})

--- a/stairsplus/stairs.lua
+++ b/stairsplus/stairs.lua
@@ -181,12 +181,6 @@ function stairsplus:register_stair(modname, subname, recipeitem, fields)
 	
 	minetest.register_craft({
 		type = "shapeless",
-		output = modname .. ":stair_" .. subname .. "_half",
-		recipe = {modname .. ":stair_" .. subname .. "_right_half"},
-	})
-	
-	minetest.register_craft({
-		type = "shapeless",
 		output = modname .. ":stair_" .. subname,
 		recipe = {modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname, modname .. ":micro_" .. subname},
 	})


### PR DESCRIPTION
This allows chopping 3-microblock stairs back into microblocks like other shapes (stairs, slabs, panels) can be crafted back into microblocks.