### PR TITLE
Add recipe for splitting alternative stairs into 4 microblocks.

### DIFF
--- a/stairsplus/microblocks.lua
+++ b/stairsplus/microblocks.lua
@@ -112,6 +112,12 @@ function stairsplus:register_micro(modname, subname, recipeitem, fields)
 	
 	minetest.register_craft({
 		type = "shapeless",
+		output = modname .. ":micro_" .. subname .. " 4",
+		recipe = {modname .. ":stair_" .. subname .. "_alt"},
+	})
+	
+	minetest.register_craft({
+		type = "shapeless",
 		output = modname .. ":micro_" .. subname .. " 3",
 		recipe = {modname .. ":stair_" .. subname .. "_right_half"},
 	})


### PR DESCRIPTION
This allows cutting 2-panel stairs into microblocks like other stuff constructed from microblocks.