### PR TITLE
Save light_source in saw's output for glowing default nodes

### DIFF
--- a/stairsplus/registrations.lua
+++ b/stairsplus/registrations.lua
@@ -56,6 +56,7 @@ for _, name in pairs(default_nodes) do
 			sounds = ndef.sounds,
 			tiles = ndef.tiles,
 			sunlight_propagates = true,
+			light_source = ndef.light_source
 		})
 	end
 end


### PR DESCRIPTION
The meselamp cutted nodes were not glowing. Fixed.