### PR TITLE
Make stairplus:register_* functions work without using register_all.

### DIFF
--- a/circular_saw.lua
+++ b/circular_saw.lua
@@ -102,9 +102,11 @@ function circular_saw:get_output_inv(modname, material, amount, max)
 		local t = circular_saw.names[i]
 		local cost = circular_saw.cost_in_microblocks[i]
 		local balance = math.min(math.floor(amount/cost), max)
-		pos = pos + 1
-		list[pos] = modname .. ":" .. t[1] .. "_" .. material .. t[2]
-				.. " " .. balance
+		local nodename = modname .. ":" .. t[1] .. "_" .. material .. t[2]
+		if  minetest.registered_nodes[nodename] then
+			pos = pos + 1
+			list[pos] = nodename .. " " .. balance
+		end
 	end
 	return list
 end

--- a/stairsplus/init.lua
+++ b/stairsplus/init.lua
@@ -17,19 +17,28 @@ and minetest.setting_getbool("creative_mode") then
 	stairsplus.expect_infinite_stacks = true
 end
 
-function stairsplus:register_all(modname, subname, recipeitem, fields)
-	fields = fields or {}
-	fields.groups = fields.groups or {}
-	if not moreblocks.config.stairsplus_in_creative_inventory then
-		fields.groups.not_in_creative_inventory = 1
+function stairsplus:prepare_groups(groups)
+	result = {}
+	if groups then
+		for k, v in pairs(groups) do
+			if k ~= "wood" and k ~= "stone" then
+				result[k] = v
+			end
+		end
 	end
+	if not moreblocks.config.stairsplus_in_creative_inventory then
+		result.not_in_creative_inventory = 1
+	end
+	return result
+end
+
+function stairsplus:register_all(modname, subname, recipeitem, fields)
 	self:register_stair(modname, subname, recipeitem, fields)
 	self:register_slab (modname, subname, recipeitem, fields)
 	self:register_slope(modname, subname, recipeitem, fields)
 	self:register_panel(modname, subname, recipeitem, fields)
 	self:register_micro(modname, subname, recipeitem, fields)
 	-- self:register_6dfacedir_conversion(modname, subname) -- Not needed as of Q3 2013, uncomment to fix old maps.
-	circular_saw.known_nodes[recipeitem] = {modname, subname}
 end
 
 function register_stair_slab_panel_micro(modname, subname, recipeitem, groups, images, description, drop, light)

--- a/stairsplus/microblocks.lua
+++ b/stairsplus/microblocks.lua
@@ -10,7 +10,7 @@ local S = moreblocks.intllib
 -- Node will be called <modname>:micro_<subname>
 
 function register_micro(modname, subname, recipeitem, groups, images, description, drop, light)
-	return stairsplus:register_micro(modname, subname, recipeitem, {
+	stairsplus:register_micro(modname, subname, recipeitem, {
 		groups = groups,
 		tiles = images,
 		description = description,
@@ -68,22 +68,24 @@ function stairsplus:register_micro(modname, subname, recipeitem, fields)
 
 	local desc = S("%s Microblock"):format(fields.description)
 	for alternate, def in pairs(defs) do
+		for k, v in pairs(fields) do
+			def[k] = v
+		end
 		def.drawtype = "nodebox"
 		def.paramtype = "light"
 		def.paramtype2 = "facedir"
 		def.on_place = minetest.rotate_node
-		for k, v in pairs(fields) do
-			def[k] = v
-		end
+		def.groups = stairsplus:prepare_groups(fields.groups)
 		def.description = desc
 		if fields.drop then
 			def.drop = modname.. ":micro_" ..fields.drop..alternate
 		end
 		minetest.register_node(":" ..modname.. ":micro_" ..subname..alternate, def)
 	end
-
 	minetest.register_alias(modname.. ":micro_" ..subname.. "_bottom", modname.. ":micro_" ..subname)
 	
+	circular_saw.known_nodes[recipeitem] = {modname, subname}
+
 	-- Some saw-less recipes:
 	
 	minetest.register_craft({

--- a/stairsplus/panels.lua
+++ b/stairsplus/panels.lua
@@ -10,7 +10,7 @@ local S = moreblocks.intllib
 -- Node will be called <modname>:panel_<subname>
 
 function register_panel(modname, subname, recipeitem, groups, images, description, drop, light)
-	return stairsplus:register_panel(modname, subname, recipeitem, {
+	stairsplus:register_panel(modname, subname, recipeitem, {
 		groups = groups,
 		tiles = images,
 		description = description,
@@ -68,14 +68,15 @@ function stairsplus:register_panel(modname, subname, recipeitem, fields)
 
 	local desc = S("%s Panel"):format(fields.description)
 	for alternate, def in pairs(defs) do
+		for k, v in pairs(fields) do
+			def[k] = v
+		end
 		def.drawtype = "nodebox"
 		def.paramtype = "light"
 		def.paramtype2 = "facedir"
 		def.on_place = minetest.rotate_node
-		for k, v in pairs(fields) do
-			def[k] = v
-		end
 		def.description = desc
+		def.groups = stairsplus:prepare_groups(fields.groups)
 		if fields.drop then
 			def.drop = modname.. ":panel_" ..fields.drop..alternate
 		end
@@ -83,6 +84,8 @@ function stairsplus:register_panel(modname, subname, recipeitem, fields)
 	end
 	minetest.register_alias(modname.. ":panel_" ..subname.. "_bottom", modname.. ":panel_" ..subname)
 	
+	circular_saw.known_nodes[recipeitem] = {modname, subname}
+
 	-- Some saw-less recipes:
 
 	minetest.register_craft({

--- a/stairsplus/registrations.lua
+++ b/stairsplus/registrations.lua
@@ -40,13 +40,6 @@ for _, name in pairs(default_nodes) do
 	local nodename = "default:" .. name
 	local ndef = minetest.registered_nodes[nodename]
 	if ndef then
-		local groups = {}
-		for k, v in pairs(ndef.groups)
-			-- Ignore wood and stone groups to not make them usable in crafting:
-			do if k ~= "wood" and k ~= "stone" then
-				groups[k] = v
-			end
-		end
 		local drop
 		if type(ndef.drop) == "string" then
 			drop = ndef.drop:sub(9)
@@ -54,7 +47,7 @@ for _, name in pairs(default_nodes) do
 		stairsplus:register_all("moreblocks", name, nodename, {
 			description = ndef.description,
 			drop = drop,
-			groups = groups,
+			groups = ndef.groups,
 			sounds = ndef.sounds,
 			tiles = ndef.tiles,
 			sunlight_propagates = true,

--- a/stairsplus/slabs.lua
+++ b/stairsplus/slabs.lua
@@ -10,7 +10,7 @@ local S = moreblocks.intllib
 -- Node will be called <modname>:slab_<subname>
 
 function register_slab(modname, subname, recipeitem, groups, images, description, drop, light)
-	return stairsplus:register_slab(modname, subname, recipeitem, {
+	stairsplus:register_slab(modname, subname, recipeitem, {
 		groups = groups,
 		tiles = images,
 		description = description,
@@ -30,6 +30,7 @@ function stairsplus:register_slab(modname, subname, recipeitem, fields)
 		["_14"] = 14,
 		["_15"] = 15,
 	}
+
 	local desc_base = S("%s Slab"):format(fields.description)
 	for alternate, num in pairs(defs) do
 		local def = {
@@ -38,20 +39,23 @@ function stairsplus:register_slab(modname, subname, recipeitem, fields)
 				fixed = {-0.5, -0.5, -0.5, 0.5, (num/16)-0.5, 0.5},
 			}
 		}
+		for k, v in pairs(fields) do
+			def[k] = v
+		end
 		def.drawtype = "nodebox"
 		def.paramtype = "light"
 		def.paramtype2 = "facedir"
 		def.on_place = minetest.rotate_node
-		for k, v in pairs(fields) do
-			def[k] = v
-		end
 		def.description = ("%s (%d/16)"):format(desc_base, num)
+		def.groups = stairsplus:prepare_groups(fields.groups)
 		if fields.drop then
 			def.drop = modname.. ":slab_" .. fields.drop .. alternate
 		end
 		minetest.register_node(":" .. modname .. ":slab_" .. subname .. alternate, def)
 	end
 	minetest.register_alias("stairs:slab_" .. subname, modname .. ":slab_" .. subname)
+
+	circular_saw.known_nodes[recipeitem] = {modname, subname}
 
 	-- Some saw-less recipes:
 

--- a/stairsplus/slopes.lua
+++ b/stairsplus/slopes.lua
@@ -113,7 +113,7 @@ local box_slope_outer_half_raised = {
 -- Node will be called <modname>:slope_<subname>
 
 function register_slope(modname, subname, recipeitem, groups, images, description, drop, light)
-	return stairsplus:register_slope(modname, subname, recipeitem, {
+	stairsplus:register_slope(modname, subname, recipeitem, {
 		groups = groups,
 		tiles = images,
 		description = description,
@@ -222,19 +222,22 @@ function stairsplus:register_slope(modname, subname, recipeitem, fields)
 
 	local desc = S("%s Slope"):format(fields.description)
 	for alternate, def in pairs(defs) do
+		for k, v in pairs(fields) do
+			def[k] = v
+		end
 		def.drawtype = "mesh"
 		def.paramtype = "light"
 		def.paramtype2 = "facedir"
 		def.on_place = minetest.rotate_node
-		for k, v in pairs(fields) do
-			def[k] = v
-		end
 		def.description = desc
+		def.groups = stairsplus:prepare_groups(fields.groups)
 		if fields.drop then
 			def.drop = modname.. ":slope_" ..fields.drop..alternate
 		end
 		minetest.register_node(":" ..modname.. ":slope_" ..subname..alternate, def)
 	end
+
+	circular_saw.known_nodes[recipeitem] = {modname, subname}
 
 	-- Some saw-less recipes:
 

--- a/stairsplus/stairs.lua
+++ b/stairsplus/stairs.lua
@@ -10,7 +10,7 @@ local S = moreblocks.intllib
 -- Node will be called <modname>:stair_<subname>
 
 function register_stair(modname, subname, recipeitem, groups, images, description, drop, light)
-	return stairsplus:register_stair(modname, subname, recipeitem, {
+	stairsplus:register_stair(modname, subname, recipeitem, {
 		groups = groups,
 		tiles = images,
 		description = description,
@@ -108,20 +108,23 @@ function stairsplus:register_stair(modname, subname, recipeitem, fields)
 
 	local desc = S("%s Stairs"):format(fields.description)
 	for alternate, def in pairs(defs) do
+		for k, v in pairs(fields) do
+			def[k] = v
+		end
 		def.drawtype = "nodebox"
 		def.paramtype = "light"
 		def.paramtype2 = "facedir"
 		def.on_place = minetest.rotate_node
-		for k, v in pairs(fields) do
-			def[k] = v
-		end
 		def.description = desc
+		def.groups = stairsplus:prepare_groups(fields.groups)
 		if fields.drop then
 			def.drop = modname .. ":stair_" .. fields.drop .. alternate
 		end
 		minetest.register_node(":" .. modname .. ":stair_" .. subname .. alternate, def)
 	end
 	minetest.register_alias("stairs:stair_" .. subname, modname .. ":stair_" .. subname)
+
+	circular_saw.known_nodes[recipeitem] = {modname, subname}
 
 	-- Some saw-less recipes:
 	


### PR DESCRIPTION
Stairplus:register_* function where not usable as is : Nodes were not added to circular saw and groups were not set as expected. That was made only by register_all function. Following changes has been made:
- Moved circular_saw.know_nodes population from stairplus:register_all to each stairplus:register_* functions;
- Added a prepare_groups function to copy groups, remove "wood" and "stone" groups and add "not in creative inventory" group and call it from each stairplus:register_* functions;
- Changed circular_saw:get_output_inv so only registered output nodes are displayed;