### PR TITLE
Resolves swapping different blocks between inventories

### DIFF
--- a/circular_saw.lua
+++ b/circular_saw.lua
@@ -289,6 +289,22 @@ end
 
 function circular_saw.on_metadata_inventory_take(
 		pos, listname, index, stack, player)
+
+	-- Prevent (inbuilt) swapping between inventories with different blocks
+	-- corrupting player inventory or Saw with 'unknown' items.
+	local meta          = minetest.get_meta(pos)
+	local inv           = meta:get_inventory()
+	local input_stack = inv:get_stack(listname,  index)
+	if not input_stack:is_empty() and input_stack:get_name()~=stack:get_name() then
+		local player_inv = player:get_inventory()
+		if player_inv:room_for_item("main", input_stack) then
+			player_inv:add_item("main", input_stack)
+		end
+
+		circular_saw:reset(pos)
+		return
+	end
+
 	-- If it is one of the offered stairs: find out how many
 	-- microblocks have to be substracted:
 	if listname == "output" then


### PR DESCRIPTION
Resolves a number of cases where switching stacks of different types of blocks with different counts would cause a corruption in the Player inventory stack count or allow normally unaccepted items into the Saw causing 'unknown' items to be generated in its output.